### PR TITLE
Add tournament admin interface with storage helpers and tests

### DIFF
--- a/storage.py
+++ b/storage.py
@@ -14,6 +14,7 @@ DB_FILES = {
 SCHEDULE_FP = os.path.join(DATA_DIR, "schedule.json")
 JUDGING_FP = os.path.join(DATA_DIR, "judging.json")
 JUDGING_LOCK_FP = os.path.join(DATA_DIR, "judging.lock")
+TOURNAMENTS_FP = os.path.join(DATA_DIR, "tournaments.json")
 DEFAULT_RATING = 1000; DEFAULT_K = 32; KO_WEIGHT = 1.10
 def ensure_dirs(): os.makedirs(DATA_DIR, exist_ok=True)
 def _blank_db():
@@ -66,6 +67,43 @@ def save_schedule(sched):
     with os.fdopen(fd,"w",encoding="utf-8") as f:
         json.dump(sched,f,indent=2,ensure_ascii=False); f.flush(); os.fsync(f.fileno())
     os.replace(tmp, SCHEDULE_FP)
+
+
+def _blank_tournaments():
+    return {"tournaments": []}
+
+
+def load_tournaments():
+    ensure_dirs()
+    if not os.path.exists(TOURNAMENTS_FP):
+        return _blank_tournaments()
+    with open(TOURNAMENTS_FP, "r", encoding="utf-8") as f:
+        try:
+            data = json.load(f)
+        except Exception:
+            return _blank_tournaments()
+    if not isinstance(data, dict):
+        return _blank_tournaments()
+    tournaments = data.get("tournaments")
+    if not isinstance(tournaments, list):
+        data["tournaments"] = []
+    return data
+
+
+def save_tournaments(data):
+    ensure_dirs()
+    if not isinstance(data, dict):
+        data = _blank_tournaments()
+    else:
+        tournaments = data.get("tournaments")
+        if not isinstance(tournaments, list):
+            data["tournaments"] = []
+    fd, tmp = tempfile.mkstemp(prefix="._elo_tournaments_", dir=DATA_DIR)
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp, TOURNAMENTS_FP)
 
 def _blank_judging_state():
     return {

--- a/templates/base.html
+++ b/templates/base.html
@@ -14,6 +14,7 @@
       <a href="{{ url_for('index', wc='Beetleweights') }}" class="{{ 'active' if request.path=='/' and request.args.get('wc')=='Beetleweights' else '' }}">Beetleweights</a>
       <a href="{{ url_for('index', wc='Sumos') }}" class="{{ 'active' if request.path=='/' and request.args.get('wc')=='Sumos' else '' }}">Sumos</a>
       <a href="{{ url_for('schedule') }}" class="{{ 'active' if request.path.startswith('/schedule') else '' }}">Schedule</a>
+      <a href="{{ url_for('tournament_admin') }}" class="{{ 'active' if request.path.startswith('/tournaments') else '' }}">Tournaments</a>
 
     </div>
     {% block body %}{% endblock %}

--- a/templates/tournament_admin.html
+++ b/templates/tournament_admin.html
@@ -1,0 +1,142 @@
+{% extends "base.html" %}
+
+{% block body %}
+<h1>Tournament Administration</h1>
+
+<section class="tournament-create">
+  <h2>Create a Tournament</h2>
+  <form method="post" action="{{ url_for('tournaments_admin_create') }}">
+    <div class="form-row">
+      <label for="tournament-name">Name</label>
+      <input id="tournament-name" type="text" name="name" required>
+    </div>
+    <div class="form-row">
+      <label for="tournament-weight-classes">Weight Classes</label>
+      <select id="tournament-weight-classes" name="weight_classes" multiple size="{{ WEIGHT_CLASSES|length }}">
+        {% for wc in WEIGHT_CLASSES %}
+        <option value="{{ wc }}">{{ wc }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="form-row">
+      <label for="tournament-elimination">Bracket Type</label>
+      <select id="tournament-elimination" name="elimination">
+        <option value="single">Single Elimination</option>
+        <option value="double">Double Elimination</option>
+      </select>
+    </div>
+    <div class="form-row">
+      <label for="tournament-cap">Robot Cap</label>
+      <input id="tournament-cap" type="number" min="0" name="robot_cap" placeholder="e.g. 16">
+    </div>
+    <div class="form-row">
+      <label for="tournament-entrants">Select Entrants</label>
+      <select id="tournament-entrants" name="entrants" multiple size="10">
+        {% for wc, robots in present_by_weight.items() %}
+          {% if robots %}
+          <optgroup label="{{ wc }}">
+            {% for robot in robots %}
+            <option value="{{ robot }}">{{ robot }}</option>
+            {% endfor %}
+          </optgroup>
+          {% endif %}
+        {% endfor %}
+      </select>
+      <p class="help-text">Only robots marked as present appear here.</p>
+    </div>
+    <button type="submit">Create Tournament</button>
+  </form>
+</section>
+
+<section class="tournament-manage">
+  <h2>Existing Tournaments</h2>
+  {% if tournaments %}
+    {% for tournament in tournaments %}
+    <article class="tournament-card">
+      <header>
+        <h3>{{ tournament.name }}</h3>
+        <p class="meta">{{ tournament.elimination|default('single')|title }} elimination &middot; Weight classes: {{ tournament.weight_classes|join(', ') }}</p>
+        <p class="meta">Robot cap: {{ tournament.robot_cap if tournament.robot_cap is not none else 'Uncapped' }}</p>
+        {% if tournament.entrants %}
+        <p class="meta">Entrants: {{ tournament.entrants|join(', ') }}</p>
+        {% else %}
+        <p class="meta">No entrants have been selected yet.</p>
+        {% endif %}
+      </header>
+
+      <section class="tournament-matches">
+        <h4>Bracket Matches</h4>
+        {% set matches = tournament.matches or [] %}
+        {% if matches %}
+          {% for match in matches %}
+          <form method="post" action="{{ url_for('tournaments_admin_update') }}" class="match-row">
+            <input type="hidden" name="tournament_id" value="{{ tournament.id }}">
+            <input type="hidden" name="action" value="set_winner">
+            <input type="hidden" name="match_id" value="{{ match.id }}">
+            <div class="match-details">
+              <strong>Round {{ match.round }}</strong> &mdash; {{ match.red }} vs {{ match.white }}
+            </div>
+            <label class="match-winner">Winner
+              <select name="winner">
+                <option value="">-- Pending --</option>
+                <option value="{{ match.red }}" {% if match.winner == match.red %}selected{% endif %}>{{ match.red }}</option>
+                <option value="{{ match.white }}" {% if match.winner == match.white %}selected{% endif %}>{{ match.white }}</option>
+              </select>
+            </label>
+            <button type="submit">Save</button>
+          </form>
+          {% endfor %}
+        {% else %}
+          <p>No matches have been created.</p>
+        {% endif %}
+      </section>
+
+      <section class="tournament-add-match">
+        <h4>Add Match</h4>
+        <form method="post" action="{{ url_for('tournaments_admin_update') }}">
+          <input type="hidden" name="tournament_id" value="{{ tournament.id }}">
+          <input type="hidden" name="action" value="add_match">
+          <div class="form-row">
+            <label>Round
+              <input type="text" name="round" value="{{ matches|length + 1 }}">
+            </label>
+          </div>
+          <div class="form-row">
+            <label>Match ID (optional)
+              <input type="text" name="match_id" placeholder="Auto if blank">
+            </label>
+          </div>
+          <div class="form-row">
+            <label>Red Robot
+              <select name="red_robot">
+                <option value="">-- Select robot --</option>
+                {% for wc, robots in present_by_weight.items() %}
+                  {% for robot in robots %}
+                  <option value="{{ robot }}">{{ robot }} ({{ wc }})</option>
+                  {% endfor %}
+                {% endfor %}
+              </select>
+            </label>
+          </div>
+          <div class="form-row">
+            <label>White Robot
+              <select name="white_robot">
+                <option value="">-- Select robot --</option>
+                {% for wc, robots in present_by_weight.items() %}
+                  {% for robot in robots %}
+                  <option value="{{ robot }}">{{ robot }} ({{ wc }})</option>
+                  {% endfor %}
+                {% endfor %}
+              </select>
+            </label>
+          </div>
+          <button type="submit">Add Match</button>
+        </form>
+      </section>
+    </article>
+    {% endfor %}
+  {% else %}
+    <p>No tournaments configured yet.</p>
+  {% endif %}
+</section>
+{% endblock %}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -24,6 +24,7 @@ class AppRoutesTestCase(unittest.TestCase):
         patched_judging_fp = os.path.join(self._tempdir.name, "judging.json")
         patched_lock_fp = os.path.join(self._tempdir.name, "judging.lock")
         patched_schedule_fp = os.path.join(self._tempdir.name, "schedule.json")
+        patched_tournaments_fp = os.path.join(self._tempdir.name, "tournaments.json")
         patched_db_files = {
             wc: os.path.join(self._tempdir.name, f"{wc.lower()}_elo.json")
             for wc in storage.DB_FILES
@@ -35,6 +36,7 @@ class AppRoutesTestCase(unittest.TestCase):
             mock.patch.object(storage, "SCHEDULE_FP", patched_schedule_fp),
             mock.patch.object(storage, "JUDGING_FP", patched_judging_fp),
             mock.patch.object(storage, "JUDGING_LOCK_FP", patched_lock_fp),
+            mock.patch.object(storage, "TOURNAMENTS_FP", patched_tournaments_fp),
             mock.patch.object(storage, "DB_FILES", patched_db_files),
         ]
         for p in self._patches:

--- a/tests/test_tournament_admin.py
+++ b/tests/test_tournament_admin.py
@@ -1,0 +1,146 @@
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+import app as bot_app
+import storage
+
+
+class TournamentAdminTestCase(unittest.TestCase):
+    def setUp(self):
+        bot_app.app.config["TESTING"] = True
+        self.client = bot_app.app.test_client()
+
+        self._tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tempdir.cleanup)
+
+        patched_judging_fp = os.path.join(self._tempdir.name, "judging.json")
+        patched_lock_fp = os.path.join(self._tempdir.name, "judging.lock")
+        patched_schedule_fp = os.path.join(self._tempdir.name, "schedule.json")
+        patched_tournaments_fp = os.path.join(self._tempdir.name, "tournaments.json")
+        patched_db_files = {
+            wc: os.path.join(self._tempdir.name, f"{wc.lower()}_elo.json")
+            for wc in storage.DB_FILES
+        }
+
+        self._patches = [
+            mock.patch.object(storage, "DATA_DIR", self._tempdir.name),
+            mock.patch.object(storage, "SCHEDULE_FP", patched_schedule_fp),
+            mock.patch.object(storage, "JUDGING_FP", patched_judging_fp),
+            mock.patch.object(storage, "JUDGING_LOCK_FP", patched_lock_fp),
+            mock.patch.object(storage, "TOURNAMENTS_FP", patched_tournaments_fp),
+            mock.patch.object(storage, "DB_FILES", patched_db_files),
+        ]
+        for patcher in self._patches:
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+        storage.ensure_dirs()
+
+    def _create_robot(self, wc, name, *, present=False):
+        db = storage.load_db(wc)
+        robots = db.setdefault("robots", {})
+        robots[name] = {"rating": 1000, "matches": [], "present": present}
+        storage.save_db(wc, db)
+
+    def test_admin_page_lists_tournaments(self):
+        wc = bot_app.WEIGHT_CLASSES[0]
+        self._create_robot(wc, "Alpha", present=True)
+        self._create_robot(wc, "Beta", present=True)
+
+        storage.save_tournaments(
+            {
+                "tournaments": [
+                    {
+                        "id": "test",
+                        "name": "Spring Invitational",
+                        "weight_classes": [wc],
+                        "elimination": "single",
+                        "robot_cap": 16,
+                        "entrants": ["Alpha", "Beta"],
+                        "matches": [
+                            {
+                                "id": "m1",
+                                "round": "1",
+                                "red": "Alpha",
+                                "white": "Beta",
+                                "winner": None,
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+
+        response = self.client.get("/tournaments/admin")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Spring Invitational", response.data)
+        self.assertIn(b"Alpha", response.data)
+        self.assertIn(b"Beta", response.data)
+
+    def test_create_tournament_persists(self):
+        wc = bot_app.WEIGHT_CLASSES[0]
+        self._create_robot(wc, "Gamma", present=True)
+
+        response = self.client.post(
+            "/tournaments/admin/create",
+            data={
+                "name": "Autumn Open",
+                "weight_classes": [wc],
+                "elimination": "double",
+                "robot_cap": "24",
+                "entrants": ["Gamma"],
+            },
+        )
+
+        self.assertEqual(response.status_code, 302)
+        tournaments = storage.load_tournaments().get("tournaments", [])
+        self.assertEqual(len(tournaments), 1)
+        created = tournaments[0]
+        self.assertEqual(created["name"], "Autumn Open")
+        self.assertEqual(created["elimination"], "double")
+        self.assertEqual(created["weight_classes"], [wc])
+        self.assertEqual(created["robot_cap"], 24)
+        self.assertEqual(created["entrants"], ["Gamma"])
+
+    def test_update_tournament_sets_winner(self):
+        wc = bot_app.WEIGHT_CLASSES[0]
+        storage.save_tournaments(
+            {
+                "tournaments": [
+                    {
+                        "id": "bracket-1",
+                        "name": "Winter Finals",
+                        "weight_classes": [wc],
+                        "elimination": "single",
+                        "robot_cap": None,
+                        "entrants": ["Alpha", "Beta"],
+                        "matches": [
+                            {
+                                "id": "match-1",
+                                "round": "1",
+                                "red": "Alpha",
+                                "white": "Beta",
+                                "winner": None,
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+
+        response = self.client.post(
+            "/tournaments/admin/update",
+            data={
+                "tournament_id": "bracket-1",
+                "action": "set_winner",
+                "match_id": "match-1",
+                "winner": "Alpha",
+            },
+        )
+
+        self.assertEqual(response.status_code, 302)
+        tournaments = storage.load_tournaments().get("tournaments", [])
+        self.assertEqual(tournaments[0]["matches"][0]["winner"], "Alpha")
+


### PR DESCRIPTION
## Summary
- add tournaments storage helpers and expose present robots for the admin view
- create a tournament administration page with forms to create brackets, manage matches, and navigation entry
- cover the new flow with Flask acceptance tests for rendering and tournament mutation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f4990ca104832abf1c49aa3eaee15a