### PR TITLE
Add public tournament bracket page and API

### DIFF
--- a/static/bracket.css
+++ b/static/bracket.css
@@ -1,0 +1,155 @@
+.bracket-wrapper {
+  overflow-x: auto;
+  padding: 12px 0 24px;
+}
+
+.bracket-section {
+  margin-bottom: 32px;
+}
+
+.bracket-section-title {
+  font-size: 20px;
+  margin: 0 0 16px;
+  color: #e53935;
+}
+
+.bracket-rounds {
+  display: flex;
+  gap: 20px;
+  min-width: 640px;
+}
+
+.bracket-round {
+  flex: 1 1 0;
+  min-width: 180px;
+}
+
+.bracket-round-title {
+  text-transform: uppercase;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  color: #888;
+  margin-bottom: 12px;
+}
+
+.bracket-round-matches {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.bracket-match {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.bracket-match.empty {
+  align-items: center;
+  justify-content: center;
+  color: #999;
+  font-style: italic;
+}
+
+.bracket-slot {
+  display: grid;
+  grid-template-columns: 40px 56px 1fr;
+  align-items: center;
+  gap: 12px;
+  padding: 8px;
+  border-radius: 6px;
+  background: rgba(18, 18, 18, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.bracket-slot.slot-bye {
+  opacity: 0.6;
+}
+
+.slot-seed {
+  font-weight: 600;
+  color: #f5f5f5;
+  text-align: center;
+}
+
+.slot-photo {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  overflow: hidden;
+  border: 2px solid rgba(229, 57, 53, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.slot-photo img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.slot-photo-fallback {
+  font-size: 18px;
+  font-weight: 700;
+  color: #e53935;
+}
+
+.slot-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.slot-name {
+  font-weight: 600;
+  color: #fff;
+}
+
+.slot-team {
+  font-size: 12px;
+  color: #bbb;
+}
+
+.slot-rating {
+  font-size: 12px;
+  color: #e0e0e0;
+}
+
+.tournament-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.tournament-title {
+  margin-bottom: 8px;
+}
+
+.updated-at {
+  font-size: 12px;
+  color: #999;
+}
+
+@media (max-width: 768px) {
+  .bracket-rounds {
+    flex-direction: column;
+    min-width: unset;
+  }
+
+  .bracket-round {
+    min-width: unset;
+  }
+
+  .bracket-slot {
+    grid-template-columns: 32px 48px 1fr;
+  }
+}

--- a/static/bracket.js
+++ b/static/bracket.js
@@ -1,0 +1,52 @@
+(function () {
+  var configEl = document.getElementById('publicBracketConfig');
+  var bracket = document.getElementById('tournamentBracket');
+  if (!configEl || !bracket) {
+    return;
+  }
+
+  var config = {};
+  try {
+    config = JSON.parse(configEl.textContent || configEl.innerText || '{}');
+  } catch (err) {
+    console.warn('Failed to parse bracket config', err);
+    return;
+  }
+
+  var apiUrl = config.apiUrl;
+  var intervalMs = parseInt(config.refreshInterval, 10);
+  if (!apiUrl || !(intervalMs > 0)) {
+    return;
+  }
+
+  var lastSeenUpdate = bracket.dataset ? bracket.dataset.updated : null;
+
+  async function pollBracket() {
+    try {
+      var response = await fetch(apiUrl, { cache: 'no-cache' });
+      if (!response.ok) {
+        return;
+      }
+      var data = await response.json();
+      if (!data || !data.meta) {
+        return;
+      }
+      var updatedValue = data.meta.updated_at;
+      if (updatedValue === null || updatedValue === undefined) {
+        return;
+      }
+      var normalized = String(updatedValue);
+      if (!lastSeenUpdate) {
+        lastSeenUpdate = normalized;
+        return;
+      }
+      if (normalized !== lastSeenUpdate) {
+        window.location.reload();
+      }
+    } catch (err) {
+      console.warn('Failed to refresh tournament bracket', err);
+    }
+  }
+
+  setInterval(pollBracket, intervalMs);
+})();

--- a/static/style.css
+++ b/static/style.css
@@ -21,6 +21,7 @@
 body{margin:0;background:var(--bg);color:var(--text);font-family:Inter, 'Segoe UI', Roboto, Arial, sans-serif}
 .container{max-width:1400px;margin:0 auto;padding:8px 16px}
 .top-tabs{display:flex;gap:8px;padding:6px 0;border-bottom:1px solid #2a2e33}
+.top-tabs a + a{margin-left:0}
 .top-tabs a{padding:6px 10px;background:#181a1d;border:1px solid #2a2e33;border-bottom:none;border-radius:6px 6px 0 0;color:#cfd8dc;text-decoration:none}
 .top-tabs a.active{background:#1f2226;color:#fff}
 .page-title{font-family:'Bank Gothic','BankGothic Md BT',Michroma,'Eurostile','Square 721',sans-serif;font-size:48px;font-weight:800;text-align:center;color:var(--red);margin:12px 0 8px;text-transform:capitalize}
@@ -66,6 +67,7 @@ td.right,th.right{text-align:right}
 label{display:block;font-size:14px;color:#cfd8dc;margin-bottom:4px}
 input,select{width:100%;background:#0f1114;color:#fff;border:1px solid #2a2e33;border-radius:6px;padding:8px}
 .badge{display:inline-block;background:#1f2226;border:1px solid #2a2e33;color:#cfd8dc;border-radius:6px;padding:4px 8px}
+.badge-accent{background:rgba(229,57,53,0.18);color:#f2f2f2;border-color:rgba(229,57,53,0.35)}
 .status{color:#cfd8dc}
 hr.sep{border:0;border-top:1px solid #2a2e33;margin:12px 0}
 .sidebar-actions{display:flex;flex-direction:column;gap:10px}
@@ -73,6 +75,9 @@ hr.sep{border:0;border-top:1px solid #2a2e33;margin:12px 0}
 .dropzone{border:1px dashed #444;background:#17191c;color:#d0d0d0;border-radius:6px;height:220px;display:flex;align-items:center;justify-content:center;text-align:center}
 img.thumb{max-width:100%;max-height:220px;display:block;margin:auto}
 .small{font-size:12px;color:#aaa}
+.tournament-link-list{list-style:none;padding:0;margin:0;display:grid;gap:6px}
+.tournament-link-list .link{color:#f5f5f5;text-decoration:underline}
+.tournament-link-list .link:hover,.tournament-link-list .link:focus{text-decoration:none}
 pre.overlay{white-space:pre-wrap;word-break:break-word;background:#0b0c0e;padding:12px;border:1px solid #2a2e33;border-radius:6px}
 
 

--- a/templates/public_base.html
+++ b/templates/public_base.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>BotBrawl</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+  {% block extra_head %}{% endblock %}
   <script src="{{ url_for('static', filename='app.js') }}"></script>
 </head>
 <body>
@@ -12,6 +13,10 @@
     <div class="top-tabs">
       <a href="{{ url_for('schedule_public') }}" class="{{ 'active' if request.path == '/SchedulePublic' else '' }}">Schedule</a>
       <a href="{{ url_for('rankings_public') }}" class="{{ 'active' if request.path == '/RankingsPublic' else '' }}">Rankings</a>
+      {% for t in PUBLIC_TOURNAMENTS %}
+        {%- set href = url_for('tournament_public', tournament_id=t.id) -%}
+        <a href="{{ href }}" class="{{ 'active' if request.path.startswith('/tournaments/public/' ~ t.id) else '' }}">{{ t.name }}</a>
+      {% endfor %}
     </div>
     {% block body %}{% endblock %}
     <dialog id="robotModal">
@@ -19,5 +24,6 @@
       <div class="modal-actions"><button class="modal-close" onclick="document.getElementById('robotModal').close()">Close</button></div>
     </dialog>
   </div>
+  {% block extra_scripts %}{% endblock %}
 </body>
 </html>

--- a/templates/public_schedule.html
+++ b/templates/public_schedule.html
@@ -27,6 +27,17 @@
   </div>
   {% endif %}
 
+  {% if PUBLIC_TOURNAMENTS %}
+  <div class="panel" style="margin-top:12px">
+    <h3 style="margin:6px 0 10px;color:#e53935">Tournaments</h3>
+    <ul class="tournament-link-list">
+      {% for tourney in PUBLIC_TOURNAMENTS %}
+        <li><a class="link" href="{{ url_for('tournament_public', tournament_id=tourney.id) }}">{{ tourney.name }}</a></li>
+      {% endfor %}
+    </ul>
+  </div>
+  {% endif %}
+
   <div class="panel" style="margin-top:12px">
     <h3 style="margin:6px 0 10px;color:#e53935">Tonight's Schedule</h3>
     {% if schedule and schedule|length > 0 %}

--- a/templates/public_tournament.html
+++ b/templates/public_tournament.html
@@ -1,0 +1,76 @@
+{% extends "public_base.html" %}
+
+{% block extra_head %}
+  {{ super() }}
+  <link rel="stylesheet" href="{{ url_for('static', filename='bracket.css') }}">
+{% endblock %}
+
+{% block body %}
+  <div class="page-title tournament-title">{{ tournament.name }}</div>
+  <div class="tournament-meta">
+    {% if tournament.weight_class %}<span class="badge">{{ tournament.weight_class }}</span>{% endif %}
+    {% if is_double_elimination %}<span class="badge badge-accent">Double Elimination</span>{% else %}<span class="badge badge-accent">Single Elimination</span>{% endif %}
+    {% if tournament.updated_at %}
+      <span class="updated-at">Updated {{ tournament.updated_at | datetimefromts }}</span>
+    {% endif %}
+  </div>
+
+  <div class="bracket-wrapper" id="tournamentBracket" data-format="{{ 'double' if is_double_elimination else 'single' }}" data-updated="{{ tournament.updated_at or '' }}">
+    {% for section in bracket_sections %}
+      <section class="bracket-section">
+        <h2 class="bracket-section-title">{{ section.title }}</h2>
+        <div class="bracket-rounds">
+          {% for round in section.rounds %}
+            <div class="bracket-round">
+              <div class="bracket-round-title">{{ round.name or 'Round ' ~ loop.index }}</div>
+              <div class="bracket-round-matches">
+                {% for match in round.matches %}
+                  <div class="bracket-match">
+                    {% for slot in match.slots %}
+                      <div class="bracket-slot{% if slot.is_bye %} slot-bye{% endif %}">
+                        <div class="slot-seed">{% if slot.seed %}#{{ slot.seed }}{% endif %}</div>
+                        <div class="slot-photo">
+                          {% if slot.robot_display.image %}
+                            <img src="{{ slot.robot_display.image }}" alt="{{ slot.robot_display.name or slot.robot or 'TBD' }} photo">
+                          {% else %}
+                            <div class="slot-photo-fallback" aria-hidden="true">{{ (slot.robot_display.name or slot.robot or 'TBD')[0] }}</div>
+                          {% endif %}
+                        </div>
+                        <div class="slot-meta">
+                          <div class="slot-name">{{ slot.robot_display.name or slot.robot or 'TBD' }}</div>
+                          {% if slot.robot_display.driver or slot.robot_display.team %}
+                            <div class="slot-team">{{ slot.robot_display.driver }}{% if slot.robot_display.team %} — {{ slot.robot_display.team }}{% endif %}</div>
+                          {% endif %}
+                          {% if slot.robot_display.rating %}
+                            <div class="slot-rating">Elo {{ slot.robot_display.rating }}</div>
+                          {% endif %}
+                        </div>
+                      </div>
+                    {% endfor %}
+                  </div>
+                {% else %}
+                  <div class="bracket-match empty">Bracket TBD</div>
+                {% endfor %}
+              </div>
+            </div>
+          {% else %}
+            <p class="small muted">No rounds configured yet.</p>
+          {% endfor %}
+        </div>
+      </section>
+    {% else %}
+      <p class="small muted">Tournament bracket coming soon.</p>
+    {% endfor %}
+  </div>
+{% endblock %}
+
+{% block extra_scripts %}
+  {{ super() }}
+  {% if refresh_seconds %}
+    <script id="publicBracketConfig" type="application/json">{{ {
+      'apiUrl': url_for('tournament_public_api', tournament_id=tournament.id),
+      'refreshInterval': refresh_seconds * 1000
+    } | tojson }}</script>
+  {% endif %}
+  <script src="{{ url_for('static', filename='bracket.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- load tournament definitions from storage and expose them on the public navigation
- add a public tournament bracket template, styling, and optional auto-refresh script
- expose a JSON tournament endpoint and integration tests covering rendering and fallbacks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f4990f6d80832aa756fbe6698da40f