### PR TITLE
Add Challonge-backed public tournament page

### DIFF
--- a/challonge_service.py
+++ b/challonge_service.py
@@ -1,0 +1,322 @@
+import importlib
+import importlib.util
+import json
+import os
+import threading
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+from urllib import parse as urllib_parse
+from urllib import request as urllib_request
+
+_REQUESTS_MODULE = None
+if importlib.util.find_spec("requests") is not None:
+    _REQUESTS_MODULE = importlib.import_module("requests")
+
+
+class ChallongeService:
+    """Fetches and caches Challonge tournament data for public views."""
+
+    API_URL_TEMPLATE = "https://api.challonge.com/v1/tournaments/{tournament}.json"
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        tournament: Optional[str] = None,
+        *,
+        session: Optional[Any] = None,
+        cache_ttl: int = 15,
+    ) -> None:
+        self._explicit_api_key = api_key
+        self._explicit_tournament = tournament
+        if session is not None:
+            self._session = session
+        elif _REQUESTS_MODULE is not None:
+            self._session = _REQUESTS_MODULE.Session()
+        else:
+            self._session = None
+        self._cache_ttl = cache_ttl
+        self._lock = threading.Lock()
+        self._cached_payload: Optional[Dict[str, Any]] = None
+        self._cached_error: Optional[str] = None
+        self._cached_at: float = 0.0
+
+    @property
+    def api_key(self) -> Optional[str]:
+        return self._explicit_api_key or os.environ.get("CHALLONGE_API_KEY")
+
+    @property
+    def tournament(self) -> Optional[str]:
+        return self._explicit_tournament or os.environ.get("CHALLONGE_TOURNAMENT")
+
+    def is_configured(self) -> bool:
+        return bool(self.api_key and self.tournament)
+
+    def _round_label(self, round_number: Optional[int]) -> str:
+        if round_number is None:
+            return "Round"
+        if round_number > 0:
+            return f"Round {round_number}"
+        if round_number < 0:
+            return f"Losers Round {abs(round_number)}"
+        return "Round"
+
+    def _score_text(self, scores_csv: Optional[str]) -> str:
+        if not scores_csv:
+            return ""
+        parts = scores_csv.split("-")
+        if len(parts) != 2:
+            return scores_csv
+        left = parts[0].strip()
+        right = parts[1].strip()
+        return f"{left} – {right}"
+
+    def _unwrap_collection(self, items: Optional[Any], key: str) -> list:
+        results: list = []
+        if not items:
+            return results
+        for item in items:
+            if isinstance(item, dict) and key in item:
+                results.append(item[key])
+            else:
+                results.append(item)
+        return results
+
+    def _normalize_payload(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        tournament = payload.get("tournament", payload)
+        participants_raw = self._unwrap_collection(tournament.get("participants"), "participant")
+        matches_raw = self._unwrap_collection(tournament.get("matches"), "match")
+
+        participants: Dict[int, Dict[str, Any]] = {}
+        normalized_participants = []
+        for part in participants_raw:
+            pid = part.get("id")
+            display_name = (
+                part.get("display_name")
+                or part.get("name")
+                or part.get("challonge_username")
+                or "TBD"
+            )
+            entry = {
+                "id": pid,
+                "name": display_name,
+                "seed": part.get("seed"),
+                "checked_in": bool(part.get("checked_in_at")),
+            }
+            normalized_participants.append(entry)
+            if pid is not None:
+                participants[pid] = entry
+
+        normalized_matches = []
+        for match in matches_raw:
+            player1_id = match.get("player1_id")
+            player2_id = match.get("player2_id")
+            winner_id = match.get("winner_id")
+            entry = {
+                "id": match.get("id"),
+                "identifier": match.get("identifier"),
+                "round": match.get("round"),
+                "round_label": self._round_label(match.get("round")),
+                "state": match.get("state"),
+                "started_at": match.get("started_at"),
+                "completed_at": match.get("completed_at"),
+                "underway_at": match.get("underway_at"),
+                "scheduled_time": match.get("scheduled_time") or match.get("scheduled_at"),
+                "updated_at": match.get("updated_at"),
+                "scores_csv": match.get("scores_csv"),
+                "score_text": self._score_text(match.get("scores_csv")),
+                "player1_id": player1_id,
+                "player2_id": player2_id,
+                "player1_name": participants.get(player1_id, {}).get("name", "TBD"),
+                "player2_name": participants.get(player2_id, {}).get("name", "TBD"),
+                "winner_id": winner_id,
+                "winner_slot": None,
+                "status_text": "",
+            }
+            if winner_id and winner_id == player1_id:
+                entry["winner_slot"] = "player1"
+            elif winner_id and winner_id == player2_id:
+                entry["winner_slot"] = "player2"
+
+            state = (match.get("state") or "").lower()
+            if state == "complete":
+                entry["status_text"] = f"{entry['round_label']} · Final"
+            elif state == "underway":
+                entry["status_text"] = f"{entry['round_label']} · In Progress"
+            elif state in {"pending", "open"}:
+                entry["status_text"] = f"{entry['round_label']} · Upcoming"
+            else:
+                entry["status_text"] = entry["round_label"]
+
+            normalized_matches.append(entry)
+
+        def sort_upcoming(item: Dict[str, Any]):
+            state = (item.get("state") or "").lower()
+            state_rank = {"underway": 0, "pending": 1, "open": 1}.get(state, 2)
+            return (
+                state_rank,
+                item.get("round") if item.get("round") is not None else 0,
+                item.get("identifier") or "",
+                item.get("id") or 0,
+            )
+
+        def sort_completed(item: Dict[str, Any]):
+            completed_at = item.get("completed_at") or ""
+            return (
+                completed_at,
+                item.get("id") or 0,
+            )
+
+        upcoming_matches = [
+            m
+            for m in normalized_matches
+            if (m.get("state") or "").lower() in {"pending", "open", "underway"}
+        ]
+        upcoming_matches.sort(key=sort_upcoming)
+
+        completed_matches = [
+            m for m in normalized_matches if (m.get("state") or "").lower() == "complete"
+        ]
+        completed_matches.sort(key=sort_completed, reverse=True)
+
+        underway_matches = [
+            m for m in normalized_matches if (m.get("state") or "").lower() == "underway"
+        ]
+
+        rounds: Dict[int, list] = {}
+        for match in normalized_matches:
+            round_number = match.get("round")
+            if round_number is None:
+                continue
+            rounds.setdefault(round_number, []).append(dict(match))
+
+        normalized_rounds = []
+        for round_number in sorted(rounds.keys()):
+            round_matches = rounds[round_number]
+            round_matches.sort(key=lambda m: (m.get("identifier") or "", m.get("id") or 0))
+            normalized_rounds.append(
+                {
+                    "round": round_number,
+                    "round_label": self._round_label(round_number),
+                    "matches": round_matches,
+                }
+            )
+
+        current_match: Optional[Dict[str, Any]] = None
+        if underway_matches:
+            current_match = underway_matches[0]
+        elif upcoming_matches:
+            current_match = upcoming_matches[0]
+
+        tournament_payload = {
+            "id": tournament.get("id"),
+            "name": tournament.get("name"),
+            "state": tournament.get("state"),
+            "game_name": tournament.get("game_name"),
+            "url": tournament.get("full_challonge_url")
+            or tournament.get("live_image_url")
+            or tournament.get("url"),
+            "started_at": tournament.get("started_at"),
+            "completed_at": tournament.get("completed_at"),
+            "updated_at": tournament.get("updated_at"),
+            "participants": normalized_participants,
+            "matches": normalized_matches,
+            "upcoming_matches": upcoming_matches[:8],
+            "recent_matches": completed_matches[:8],
+            "current_match": current_match,
+            "rounds": normalized_rounds,
+            "total_participants": len(normalized_participants),
+            "total_matches": len(normalized_matches),
+        }
+        return tournament_payload
+
+    def _fetch(self) -> Dict[str, Any]:
+        api_key = self.api_key
+        tournament = self.tournament
+        if not api_key or not tournament:
+            raise RuntimeError("Challonge API key or tournament not configured")
+
+        url = self.API_URL_TEMPLATE.format(tournament=tournament)
+        params = {
+            "api_key": api_key,
+            "include_matches": 1,
+            "include_participants": 1,
+        }
+        if self._session is not None and hasattr(self._session, "get"):
+            response = self._session.get(url, params=params, timeout=10)
+            response.raise_for_status()
+            payload = response.json()
+        else:
+            query = urllib_parse.urlencode(params)
+            full_url = f"{url}?{query}"
+            with urllib_request.urlopen(full_url, timeout=10) as resp:
+                data = resp.read()
+                charset = None
+                headers = getattr(resp, "headers", None)
+                if headers is not None and hasattr(headers, "get_content_charset"):
+                    charset = headers.get_content_charset()
+            payload = json.loads(data.decode(charset or "utf-8"))
+        return self._normalize_payload(payload)
+
+    def get_tournament(self, force_refresh: bool = False) -> Dict[str, Any]:
+        now = time.time()
+        with self._lock:
+            cache_fresh = (
+                self._cached_payload is not None
+                and not force_refresh
+                and (now - self._cached_at) < self._cache_ttl
+            )
+            if cache_fresh:
+                return {
+                    "configured": self.is_configured(),
+                    "error": self._cached_error,
+                    "tournament": self._cached_payload,
+                    "fetched_at": self._cached_payload.get("_fetched_at") if self._cached_payload else None,
+                    "cached": True,
+                }
+
+        if not self.is_configured():
+            message = "Challonge integration is not configured."
+            with self._lock:
+                self._cached_error = message
+                self._cached_payload = None
+                self._cached_at = now
+            return {
+                "configured": False,
+                "error": message,
+                "tournament": None,
+                "fetched_at": None,
+                "cached": False,
+            }
+
+        try:
+            tournament_payload = self._fetch()
+            fetched_at = datetime.now(timezone.utc).isoformat()
+            tournament_payload["_fetched_at"] = fetched_at
+            with self._lock:
+                self._cached_payload = tournament_payload
+                self._cached_error = None
+                self._cached_at = now
+            return {
+                "configured": True,
+                "error": None,
+                "tournament": tournament_payload,
+                "fetched_at": fetched_at,
+                "cached": False,
+            }
+        except Exception as exc:  # noqa: BLE001
+            message = f"Failed to fetch Challonge data: {exc}".strip()
+            with self._lock:
+                self._cached_error = message
+                self._cached_at = now
+            return {
+                "configured": True,
+                "error": message,
+                "tournament": self._cached_payload,
+                "fetched_at": self._cached_payload.get("_fetched_at") if self._cached_payload else None,
+                "cached": self._cached_payload is not None,
+            }
+
+
+def get_service() -> ChallongeService:
+    return ChallongeService()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask==3.0.3
 gunicorn==22.0.0
+requests==2.32.3

--- a/static/challonge_live.js
+++ b/static/challonge_live.js
@@ -1,0 +1,312 @@
+(function () {
+  const API_URL = '/api/challonge/tournament';
+  const REFRESH_MS = 15000;
+
+  const stateStrings = {
+    complete: 'Final',
+    underway: 'In Progress',
+    pending: 'Upcoming',
+    open: 'Upcoming'
+  };
+
+  function removeContent(section) {
+    if (!section) return;
+    while (section.children.length > 1) {
+      section.removeChild(section.lastElementChild);
+    }
+  }
+
+  function createMatchRow(match) {
+    const li = document.createElement('li');
+    li.className = 'match-row';
+    if (match && match.id !== undefined && match.id !== null) {
+      li.dataset.matchId = match.id;
+    }
+
+    const round = document.createElement('div');
+    round.className = 'match-round';
+    round.textContent = match?.round_label || 'Round';
+    li.appendChild(round);
+
+    const players = document.createElement('div');
+    players.className = 'match-players';
+
+    const player1 = document.createElement('span');
+    player1.className = 'match-player';
+    player1.textContent = match?.player1_name || 'TBD';
+    if (match?.winner_slot === 'player1') {
+      player1.classList.add('winner');
+    }
+
+    const vs = document.createElement('span');
+    vs.className = 'match-vs';
+    vs.textContent = 'vs';
+
+    const player2 = document.createElement('span');
+    player2.className = 'match-player';
+    player2.textContent = match?.player2_name || 'TBD';
+    if (match?.winner_slot === 'player2') {
+      player2.classList.add('winner');
+    }
+
+    players.appendChild(player1);
+    players.appendChild(vs);
+    players.appendChild(player2);
+    li.appendChild(players);
+
+    const meta = document.createElement('div');
+    meta.className = 'match-meta';
+    if (match?.score_text) {
+      const score = document.createElement('span');
+      score.className = 'match-score';
+      score.textContent = match.score_text;
+      meta.appendChild(score);
+    }
+    const state = document.createElement('span');
+    state.className = 'match-state';
+    state.textContent = match?.status_text || '';
+    meta.appendChild(state);
+    li.appendChild(meta);
+    return li;
+  }
+
+  function renderMatchList(section, matches, emptyText) {
+    if (!section) return;
+    removeContent(section);
+    if (!matches || !matches.length) {
+      const empty = document.createElement('p');
+      empty.className = 'empty-copy';
+      empty.textContent = emptyText;
+      section.appendChild(empty);
+      return;
+    }
+    const list = document.createElement('ul');
+    list.className = 'match-list';
+    matches.forEach((match) => {
+      list.appendChild(createMatchRow(match));
+    });
+    section.appendChild(list);
+  }
+
+  function renderCurrent(section, match) {
+    if (!section) return;
+    removeContent(section);
+    if (!match) {
+      const empty = document.createElement('p');
+      empty.className = 'empty-copy';
+      empty.textContent = 'No live match right now.';
+      section.appendChild(empty);
+      return;
+    }
+    const card = document.createElement('div');
+    card.className = 'current-match-card';
+    if (match.id !== undefined && match.id !== null) {
+      card.dataset.currentMatchId = match.id;
+    }
+    const round = document.createElement('div');
+    round.className = 'match-round';
+    round.textContent = match.round_label || 'Round';
+    card.appendChild(round);
+
+    const versus = document.createElement('div');
+    versus.className = 'current-versus';
+
+    const player1 = document.createElement('div');
+    player1.className = 'current-player';
+    player1.textContent = match.player1_name || 'TBD';
+    if (match.winner_slot === 'player1') {
+      player1.classList.add('winner');
+    }
+
+    const vs = document.createElement('div');
+    vs.className = 'current-vs';
+    vs.textContent = 'vs';
+
+    const player2 = document.createElement('div');
+    player2.className = 'current-player';
+    player2.textContent = match.player2_name || 'TBD';
+    if (match.winner_slot === 'player2') {
+      player2.classList.add('winner');
+    }
+
+    versus.appendChild(player1);
+    versus.appendChild(vs);
+    versus.appendChild(player2);
+    card.appendChild(versus);
+
+    const meta = document.createElement('div');
+    meta.className = 'current-meta';
+    if (match.score_text) {
+      const score = document.createElement('span');
+      score.className = 'match-score';
+      score.textContent = match.score_text;
+      meta.appendChild(score);
+    }
+    const state = document.createElement('span');
+    state.className = 'match-state';
+    state.textContent = match.status_text || '';
+    meta.appendChild(state);
+    card.appendChild(meta);
+    section.appendChild(card);
+  }
+
+  function renderRounds(section, rounds) {
+    if (!section) return;
+    removeContent(section);
+    if (!rounds || !rounds.length) {
+      const empty = document.createElement('p');
+      empty.className = 'empty-copy';
+      empty.textContent = 'Bracket data will appear once matches are seeded.';
+      section.appendChild(empty);
+      return;
+    }
+    const grid = document.createElement('div');
+    grid.className = 'rounds-grid';
+    rounds.forEach((round) => {
+      const card = document.createElement('div');
+      card.className = 'round-card';
+      if (round.round !== undefined && round.round !== null) {
+        card.dataset.round = round.round;
+      }
+      const title = document.createElement('h4');
+      title.className = 'round-title';
+      title.textContent = round.round_label || `Round ${round.round ?? ''}`;
+      card.appendChild(title);
+
+      const list = document.createElement('ul');
+      list.className = 'match-list compact';
+      (round.matches || []).forEach((match) => {
+        list.appendChild(createMatchRow(match));
+      });
+      card.appendChild(list);
+      grid.appendChild(card);
+    });
+    section.appendChild(grid);
+  }
+
+  function updateStatus(root, payload) {
+    if (!root) return;
+    const section = root.querySelector('[data-challonge-status]');
+    if (!section) return;
+    const tournament = payload?.tournament || null;
+    const nameEl = section.querySelector('[data-challonge-name]');
+    if (nameEl) {
+      nameEl.textContent = tournament?.name || 'Challonge Tournament';
+    }
+    const stateEl = section.querySelector('[data-challonge-state]');
+    if (stateEl) {
+      if (tournament?.state) {
+        const stateLabel = stateStrings[(tournament.state || '').toLowerCase()] || tournament.state;
+        stateEl.textContent = '';
+        const prefix = document.createTextNode('State: ');
+        const highlight = document.createElement('span');
+        highlight.className = 'highlight';
+        highlight.textContent = stateLabel;
+        stateEl.appendChild(prefix);
+        stateEl.appendChild(highlight);
+      } else {
+        stateEl.textContent = 'Waiting for tournament details';
+      }
+    }
+    const participantsEl = section.querySelector('[data-challonge-participants]');
+    if (participantsEl) {
+      participantsEl.textContent = tournament?.total_participants != null ? tournament.total_participants : '—';
+    }
+    const matchesEl = section.querySelector('[data-challonge-matches]');
+    if (matchesEl) {
+      matchesEl.textContent = tournament?.total_matches != null ? tournament.total_matches : '—';
+    }
+    const updatedEl = section.querySelector('[data-challonge-updated]');
+    if (updatedEl) {
+      updatedEl.textContent = payload?.fetched_at || '—';
+    }
+    const linkEl = section.querySelector('[data-challonge-link]');
+    if (linkEl) {
+      const url = tournament?.url;
+      if (url) {
+        linkEl.href = url;
+        linkEl.removeAttribute('hidden');
+      } else {
+        linkEl.href = '#';
+        linkEl.setAttribute('hidden', '');
+      }
+    }
+    const errorEl = section.querySelector('[data-challonge-error]');
+    if (errorEl) {
+      const configured = payload?.configured !== false;
+      const error = payload?.error;
+      if (!configured) {
+        errorEl.textContent = 'Challonge integration is not configured.';
+        errorEl.removeAttribute('hidden');
+      } else if (error) {
+        errorEl.textContent = error;
+        errorEl.removeAttribute('hidden');
+      } else {
+        errorEl.textContent = '';
+        errorEl.setAttribute('hidden', '');
+      }
+    }
+  }
+
+  function applyPayload(root, payload) {
+    if (!root) return;
+    updateStatus(root, payload);
+    const tournament = payload?.tournament || null;
+    const currentSection = root.querySelector('[data-challonge-current]');
+    renderCurrent(currentSection, tournament?.current_match || null);
+
+    const upcomingSection = root.querySelector('[data-challonge-upcoming]');
+    renderMatchList(
+      upcomingSection,
+      tournament?.upcoming_matches || [],
+      'No upcoming matches have been posted.'
+    );
+
+    const recentSection = root.querySelector('[data-challonge-recent]');
+    renderMatchList(
+      recentSection,
+      tournament?.recent_matches || [],
+      'No matches have been completed yet.'
+    );
+
+    const roundsSection = root.querySelector('[data-challonge-rounds]');
+    renderRounds(roundsSection, tournament?.rounds || []);
+  }
+
+  function fetchAndRender(root, scheduleNext) {
+    fetch(API_URL, { cache: 'no-store' })
+      .then((response) => response.json().then((data) => ({ ok: response.ok, data })))
+      .then(({ ok, data }) => {
+        if (!ok) {
+          data = data || {};
+          data.error = data.error || 'Unable to load tournament data.';
+        }
+        applyPayload(root, data);
+        scheduleNext();
+      })
+      .catch((error) => {
+        console.error('Challonge live update failed', error);
+        applyPayload(root, {
+          configured: true,
+          error: 'Unable to load tournament data.',
+          tournament: null,
+        });
+        scheduleNext();
+      });
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const root = document.querySelector('[data-challonge-root]');
+    if (!root) return;
+
+    let timer = null;
+    const scheduleNext = () => {
+      if (timer) {
+        clearTimeout(timer);
+      }
+      timer = setTimeout(() => fetchAndRender(root, scheduleNext), REFRESH_MS);
+    };
+
+    fetchAndRender(root, scheduleNext);
+  });
+})();

--- a/static/style.css
+++ b/static/style.css
@@ -169,3 +169,43 @@ dialog::backdrop{background:rgba(0,0,0,0.65)}
   .judge-fight-card{grid-template-columns:1fr;justify-items:center}
   .judge-controls{order:3}
 }
+
+/* Tournament page */
+.challonge-wrapper{display:grid;gap:16px}
+.tournament-status .tournament-heading{display:flex;flex-wrap:wrap;justify-content:space-between;gap:16px;align-items:flex-start}
+.tournament-name{margin:0;font-family:'Bank Gothic','BankGothic Md BT',Michroma,'Eurostile','Square 721',sans-serif;font-size:36px;letter-spacing:0.5px}
+.tournament-subtitle{margin:4px 0 0;color:var(--muted);font-size:15px}
+.tournament-subtitle .highlight{color:var(--red);font-weight:600}
+.tournament-meta{display:flex;gap:12px;flex-wrap:wrap}
+.tournament-meta > div{background:var(--panel2);border:1px solid #2a2e33;border-radius:6px;padding:8px 12px;min-width:120px}
+.tournament-meta .meta-label{display:block;font-size:12px;text-transform:uppercase;letter-spacing:0.05em;color:var(--muted)}
+.tournament-meta .meta-value{display:block;font-size:20px;font-weight:700;color:#fff}
+.tournament-links{margin-top:12px;display:flex;flex-wrap:wrap;gap:12px;align-items:center}
+.error-chip{background:rgba(229,57,53,0.18);border:1px solid #e53935;color:#ff8a80;border-radius:999px;padding:6px 12px;font-size:13px}
+.panel-title{margin:0 0 8px;font-size:20px;font-weight:700;color:var(--red);text-transform:uppercase;letter-spacing:0.08em}
+.empty-copy{margin:4px 0 0;color:var(--muted);font-size:15px}
+.match-list{list-style:none;margin:0;padding:0;display:grid;gap:8px}
+.match-list.compact{gap:6px}
+.match-row{display:grid;gap:12px;grid-template-columns:minmax(120px,140px) 1fr minmax(140px,auto);align-items:center;background:var(--panel2);border:1px solid #2a2e33;border-radius:6px;padding:8px 12px}
+.match-round{font-size:13px;text-transform:uppercase;letter-spacing:0.04em;color:var(--muted)}
+.match-players{display:flex;align-items:center;gap:8px;font-weight:600;font-size:17px;flex-wrap:wrap}
+.match-player{color:#fff}
+.match-player.winner{color:var(--green)}
+.match-vs{color:var(--muted);font-size:14px;text-transform:uppercase;letter-spacing:0.04em}
+.match-meta{display:flex;gap:8px;justify-content:flex-end;flex-wrap:wrap;font-size:13px;color:var(--muted)}
+.match-score{background:rgba(62,166,255,0.12);border:1px solid rgba(62,166,255,0.35);border-radius:999px;padding:3px 10px;color:#8ecbff;font-weight:600}
+.current-match-card{background:var(--panel2);border:1px solid #2a2e33;border-radius:6px;padding:12px;display:grid;gap:12px}
+.current-versus{display:flex;flex-wrap:wrap;gap:12px;align-items:center;justify-content:center;font-size:24px;font-weight:700}
+.current-player{color:#fff;min-width:0}
+.current-player.winner{color:var(--green)}
+.current-vs{color:var(--red);font-size:26px;letter-spacing:0.08em;text-transform:uppercase}
+.current-meta{display:flex;gap:10px;justify-content:center;flex-wrap:wrap;font-size:14px;color:var(--muted)}
+.rounds-grid{display:grid;gap:12px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+.round-card{background:var(--panel2);border:1px solid #2a2e33;border-radius:6px;padding:10px;display:grid;gap:8px}
+.round-title{margin:0;font-size:18px;font-weight:700;color:#fff;text-transform:uppercase;letter-spacing:0.05em}
+
+@media (max-width: 900px){
+  .tournament-main{grid-template-columns:1fr}
+  .match-row{grid-template-columns:1fr}
+  .match-meta{justify-content:flex-start}
+}

--- a/templates/public_base.html
+++ b/templates/public_base.html
@@ -12,6 +12,7 @@
     <div class="top-tabs">
       <a href="{{ url_for('schedule_public') }}" class="{{ 'active' if request.path == '/SchedulePublic' else '' }}">Schedule</a>
       <a href="{{ url_for('rankings_public') }}" class="{{ 'active' if request.path == '/RankingsPublic' else '' }}">Rankings</a>
+      <a href="{{ url_for('tournament_public') }}" class="{{ 'active' if request.path == '/TournamentPublic' else '' }}">Tournament</a>
     </div>
     {% block body %}{% endblock %}
     <dialog id="robotModal">

--- a/templates/public_tournament.html
+++ b/templates/public_tournament.html
@@ -1,0 +1,125 @@
+{% extends "public_base.html" %}
+{% block body %}
+{% set payload = challonge or {} %}
+{% set tournament = payload.get('tournament') %}
+<h1 class="page-title">Tournament</h1>
+
+{% macro match_row(match) -%}
+<li class="match-row" data-match-id="{{ match.get('id') }}">
+  <div class="match-round">{{ match.get('round_label') or 'Round' }}</div>
+  <div class="match-players">
+    <span class="match-player {{ 'winner' if match.get('winner_slot') == 'player1' else '' }}">{{ match.get('player1_name') or 'TBD' }}</span>
+    <span class="match-vs">vs</span>
+    <span class="match-player {{ 'winner' if match.get('winner_slot') == 'player2' else '' }}">{{ match.get('player2_name') or 'TBD' }}</span>
+  </div>
+  <div class="match-meta">
+    {% if match.get('score_text') %}<span class="match-score">{{ match.get('score_text') }}</span>{% endif %}
+    <span class="match-state">{{ match.get('status_text') }}</span>
+  </div>
+</li>
+{%- endmacro %}
+
+<div class="challonge-wrapper" data-challonge-root>
+  <section class="panel tournament-status" data-challonge-status>
+    <div class="tournament-heading">
+      <div>
+        <h2 class="tournament-name" data-challonge-name>{{ tournament.get('name') if tournament else 'Challonge Tournament' }}</h2>
+        <p class="tournament-subtitle" data-challonge-state>
+          {% if tournament and tournament.get('state') %}
+            State: <span class="highlight">{{ tournament.get('state')|capitalize }}</span>
+          {% else %}
+            Waiting for tournament details
+          {% endif %}
+        </p>
+      </div>
+      <div class="tournament-meta">
+        <div><span class="meta-label">Participants</span><span class="meta-value" data-challonge-participants>{{ tournament.get('total_participants') if tournament else '—' }}</span></div>
+        <div><span class="meta-label">Matches</span><span class="meta-value" data-challonge-matches>{{ tournament.get('total_matches') if tournament else '—' }}</span></div>
+        <div><span class="meta-label">Last Update</span><span class="meta-value" data-challonge-updated>{{ payload.get('fetched_at') or '—' }}</span></div>
+      </div>
+    </div>
+    <div class="tournament-links">
+      <a class="btn btn-ghost" data-challonge-link href="{{ tournament.get('url') if tournament else '#' }}" target="_blank" rel="noopener" {% if not tournament or not tournament.get('url') %}hidden{% endif %}>View on Challonge</a>
+      {% set config_message = 'Challonge integration is not configured.' %}
+      {% if payload.get('error') %}
+        <span class="error-chip" data-challonge-error>{{ payload.get('error') }}</span>
+      {% elif not payload.get('configured', True) %}
+        <span class="error-chip" data-challonge-error>{{ config_message }}</span>
+      {% else %}
+        <span class="error-chip" data-challonge-error hidden></span>
+      {% endif %}
+    </div>
+  </section>
+
+  <div class="grid grid-2 tournament-main">
+    <section class="panel current-match" data-challonge-current>
+      <h3 class="panel-title">Current Match</h3>
+      {% if tournament and tournament.get('current_match') %}
+        {% set match = tournament.get('current_match') %}
+        <div class="current-match-card" data-current-match-id="{{ match.get('id') }}">
+          <div class="match-round">{{ match.get('round_label') or 'Round' }}</div>
+          <div class="current-versus">
+            <div class="current-player {{ 'winner' if match.get('winner_slot') == 'player1' else '' }}">{{ match.get('player1_name') or 'TBD' }}</div>
+            <div class="current-vs">vs</div>
+            <div class="current-player {{ 'winner' if match.get('winner_slot') == 'player2' else '' }}">{{ match.get('player2_name') or 'TBD' }}</div>
+          </div>
+          <div class="current-meta">
+            {% if match.get('score_text') %}<span class="match-score">{{ match.get('score_text') }}</span>{% endif %}
+            <span class="match-state">{{ match.get('status_text') }}</span>
+          </div>
+        </div>
+      {% else %}
+        <p class="empty-copy">No live match right now.</p>
+      {% endif %}
+    </section>
+
+    <section class="panel upcoming-matches" data-challonge-upcoming>
+      <h3 class="panel-title">Upcoming Matches</h3>
+      {% if tournament and tournament.get('upcoming_matches') %}
+        <ul class="match-list">
+          {% for match in tournament.get('upcoming_matches') %}
+            {{ match_row(match) }}
+          {% endfor %}
+        </ul>
+      {% else %}
+        <p class="empty-copy">No upcoming matches have been posted.</p>
+      {% endif %}
+    </section>
+  </div>
+
+  <section class="panel recent-matches" data-challonge-recent>
+    <h3 class="panel-title">Recent Results</h3>
+    {% if tournament and tournament.get('recent_matches') %}
+      <ul class="match-list">
+        {% for match in tournament.get('recent_matches') %}
+          {{ match_row(match) }}
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p class="empty-copy">No matches have been completed yet.</p>
+    {% endif %}
+  </section>
+
+  <section class="panel bracket-overview" data-challonge-rounds>
+    <h3 class="panel-title">Bracket Overview</h3>
+    {% if tournament and tournament.get('rounds') %}
+      <div class="rounds-grid">
+        {% for round in tournament.get('rounds') %}
+          <div class="round-card" data-round="{{ round.get('round') }}">
+            <h4 class="round-title">{{ round.get('round_label') }}</h4>
+            <ul class="match-list compact">
+              {% for match in round.get('matches') %}
+                {{ match_row(match) }}
+              {% endfor %}
+            </ul>
+          </div>
+        {% endfor %}
+      </div>
+    {% else %}
+      <p class="empty-copy">Bracket data will appear once matches are seeded.</p>
+    {% endif %}
+  </section>
+</div>
+
+<script src="{{ url_for('static', filename='challonge_live.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a Challonge service that fetches and caches tournament data for reuse
- expose a public tournament API and page wired to the new template and styling
- implement live polling JavaScript and regression tests for the new routes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f9dd147fbc832a95be4d51b15a9497